### PR TITLE
Create the GitHub Release from the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
     # publications have to go up in one deployment.
     runs-on: macos-15
     timeout-minutes: 60
+    # Widened from the workflow-level `contents: read` solely to create the GitHub
+    # Release below. Everything else here writes to Maven Central using its own
+    # credentials, not the GitHub token.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6
@@ -93,3 +98,16 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+
+      # Only after Maven Central has accepted the release — a GitHub Release pointing at
+      # artifacts that never published would be worse than none. Skipped for snapshots,
+      # which are not releases and are overwritten freely.
+      #
+      # `gh` is preinstalled on the runner, so this adds no third-party action to the one
+      # job holding the signing key and the Portal token. `--verify-tag` refuses to invent
+      # a tag if the ref is somehow wrong.
+      - name: Create the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v') && inputs.snapshot != true
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Pushing a tag creates a tag, not a Release — the v1.0.0 tag landed with no Release object, and the 0.x ones were all made by hand in 2020 and 2021. This closes that gap.

Uses gh release create rather than a third-party action. gh is preinstalled on the runner, so nothing new enters the one job that holds the signing key and the Portal token, and there is no action version to pin or track. The usual argument for softprops/action-gh-release is its asset handling, which does not apply here: the artifacts go to Maven Central, not to the Release. The trade is idempotency — re-running a failed publish on an existing tag will fail at this step rather than updating the release.

The step runs only after Maven Central has accepted the release, since a Release pointing at artifacts that never published would be worse than none, and is skipped for snapshots. contents: write is scoped to this job alone; the workflow default stays contents: read.