### PR TITLE
Add a desktop sample so the pickers can be seen without an emulator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 apiValidation {
     // Sample modules are not published; only the library's API surface is tracked.
-    ignoredProjects += listOf("androidApp", "shared")
+    ignoredProjects += listOf("androidApp", "desktopApp", "shared")
 
     @OptIn(ExperimentalBCVApi::class)
     klib {

--- a/sample/desktopApp/build.gradle.kts
+++ b/sample/desktopApp/build.gradle.kts
@@ -1,0 +1,30 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+}
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        jvmMain.dependencies {
+            implementation(project(":sample:shared"))
+            implementation(compose.desktop.currentOs)
+        }
+    }
+}
+
+compose.desktop {
+    application {
+        mainClass = "codes.side.colorpicker.sample.MainKt"
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "anyColorPicker Sample"
+            packageVersion = providers.gradleProperty("VERSION_NAME").get()
+        }
+    }
+}

--- a/sample/desktopApp/src/jvmMain/kotlin/codes/side/colorpicker/sample/main.kt
+++ b/sample/desktopApp/src/jvmMain/kotlin/codes/side/colorpicker/sample/main.kt
@@ -1,0 +1,23 @@
+package codes.side.colorpicker.sample
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+
+/**
+ * Runs the shared sample on the desktop: `./gradlew :sample:desktopApp:run`.
+ *
+ * The same [SampleApp] the Android and iOS samples use, so the pickers can be looked at
+ * without an emulator or a device.
+ */
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "anyColorPicker",
+        state = rememberWindowState(size = DpSize(720.dp, 960.dp)),
+    ) {
+        SampleApp()
+    }
+}

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -9,6 +9,9 @@ plugins {
 }
 
 kotlin {
+    // Consumed by the desktop sample; the library already publishes a jvm target.
+    jvm()
+
     android {
         namespace = "codes.side.colorpicker.sample.shared"
         compileSdk = 37

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,3 +34,4 @@ rootProject.name = "anyColorPicker"
 include(":colorpicker")
 include(":sample:shared")
 include(":sample:androidApp")
+include(":sample:desktopApp")


### PR DESCRIPTION
There was no way to look at this library running short of an Android emulator or an Xcode simulator, which makes any visual judgement — contrast, gradients, thumb visibility — slow to check and easy to get wrong. ./gradlew :sample:desktopApp:run now opens the same SampleApp the Android and iOS samples use.

The library needed nothing: it already publishes a jvm target, which is what the Compose UI tests render against. sample/shared gains jvm() so the new module can consume it, and the module itself is a thin main() around the existing shared composable.

desktopApp joins androidApp and shared in apiValidation's ignoredProjects. Without that, apiCheck tries to extract a public API surface from a sample application and fails.

Verified by running it, not just compiling: the window opens and renders the swatch, both coloring modes, the hex and HSL/RGB/CMYK/LAB readouts, and the HSL and RGB slider stacks with visible thumbs.