### PR TITLE
Register the golden-copy task without the deprecated delegate

### DIFF
--- a/screenshot-tests/build.gradle.kts
+++ b/screenshot-tests/build.gradle.kts
@@ -55,7 +55,7 @@ val readmeGoldens = mapOf(
 
 val docsImageDir = rootProject.layout.projectDirectory.dir("docs/images")
 
-val copyGoldensToDocs by tasks.registering(Copy::class) {
+val copyGoldensToDocs = tasks.register<Copy>("copyGoldensToDocs") {
     description = "Copies screenshot-test references into docs/images under README-stable names."
     from(layout.projectDirectory.dir("src/screenshotTestDebug/reference"))
     include("**/*.png")


### PR DESCRIPTION
`val copyGoldensToDocs by tasks.registering(Copy::class)` uses the Kotlin DSL property-delegate syntax that Gradle 9 deprecates and Gradle 10 removes, and it was the only deprecation left in the build. `tasks.register<Copy>("copyGoldensToDocs")` is the documented replacement and changes nothing about when the task runs.