### PR TITLE
Name Kotlin Multiplatform in the published description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # anyColorPicker
 
-Multiplatform color picker library for Android, iOS, Desktop (JVM), and Web (Wasm), built with Compose Multiplatform and Material 3.
+Kotlin Multiplatform color picker library for Android, iOS, Desktop (JVM), and Web (Wasm), built with Compose Multiplatform and Material 3.
 
 ## ✨ Features
 

--- a/colorpicker/build.gradle.kts
+++ b/colorpicker/build.gradle.kts
@@ -121,7 +121,7 @@ mavenPublishing {
 
     pom {
         name.set("anyColorPicker")
-        description.set("Multiplatform color picker library for Android & iOS")
+        description.set("Kotlin Multiplatform color picker library for Android, iOS, Desktop (JVM), and Web (Wasm), built with Compose Multiplatform and Material 3")
         inceptionYear.set("2020")
         url.set("https://github.com/side-codes/anyColorPicker")
         licenses {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # anyColorPicker — Compose Multiplatform Color Picker
 
-Multiplatform color picker library for Android, iOS, Desktop (JVM), and Web (Wasm), built with Compose Multiplatform and Material 3.
+Kotlin Multiplatform color picker library for Android, iOS, Desktop (JVM), and Web (Wasm), built with Compose Multiplatform and Material 3.
 
 ## ✨ Features
 


### PR DESCRIPTION
The POM description still read "for Android & iOS" from before the multiplatform rewrite, and that string is what Central and klibs.io display. klibs.io is a Kotlin Multiplatform index, so a description that never says the words is a weak entry there. The README and its docs/ mirror carry the same sentence and move with it.