### PR TITLE
Run Gradle tooling sync in parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ VERSION_NAME=1.1.0
 
 # Required by com.android.compose.screenshot (Compose Preview Screenshot Testing).
 android.experimental.enableScreenshotTest=true
+
+# Parallel sync, for Gradle 9.4+.
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Sync configures projects serially by default, which this build feels across its six modules and their multiplatform target sets.