### PR TITLE
Bump the version to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Kotlin Multiplatform color picker library for Android, iOS, Desktop (JVM), and W
 
 ```kotlin
 // build.gradle.kts
-implementation("codes.side:colorpicker:1.1.0")
+implementation("codes.side:colorpicker:1.1.1")
 ```
 
 In a Kotlin Multiplatform project, add it to `commonMain`:
@@ -27,7 +27,7 @@ In a Kotlin Multiplatform project, add it to `commonMain`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("codes.side:colorpicker:1.1.0")
+            implementation("codes.side:colorpicker:1.1.1")
         }
     }
 }
@@ -418,7 +418,7 @@ The View-based `codes.side:andcolorpicker` artifact (XML `HSLColorPickerSeekBar`
 
 ```diff
 - implementation("codes.side:andcolorpicker:0.6.2")
-+ implementation("codes.side:colorpicker:1.1.0")
++ implementation("codes.side:colorpicker:1.1.1")
 ```
 
 There is no 1:1 API mapping — migrate by concept:

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Kotlin Multiplatform color picker library for Android, iOS, Desktop (JVM), and W
 
 ```kotlin
 // build.gradle.kts
-implementation("codes.side:colorpicker:1.1.0")
+implementation("codes.side:colorpicker:1.1.1")
 ```
 
 In a Kotlin Multiplatform project, add it to `commonMain`:
@@ -27,7 +27,7 @@ In a Kotlin Multiplatform project, add it to `commonMain`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("codes.side:colorpicker:1.1.0")
+            implementation("codes.side:colorpicker:1.1.1")
         }
     }
 }
@@ -418,7 +418,7 @@ The View-based `codes.side:andcolorpicker` artifact (XML `HSLColorPickerSeekBar`
 
 ```diff
 - implementation("codes.side:andcolorpicker:0.6.2")
-+ implementation("codes.side:colorpicker:1.1.0")
++ implementation("codes.side:colorpicker:1.1.1")
 ```
 
 There is no 1:1 API mapping — migrate by concept:

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Published version. Single source of truth: the release workflow checks the git tag
 # against this and fails if they disagree, so a tag can never publish a different
 # version. Maven Central is immutable, which makes that mistake unrecoverable.
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 
 # Required by com.android.compose.screenshot (Compose Preview Screenshot Testing).
 android.experimental.enableScreenshotTest=true

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = 24
         targetSdk = 37
         versionCode = 1
-        versionName = "1.1.0"
+        versionName = "1.1.1"
     }
 
     compileOptions {


### PR DESCRIPTION
Nothing under colorpicker/src changed. The release exists to get the corrected POM description onto Central, where 1.1.0 still advertises an Android-and-iOS library.